### PR TITLE
Go SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,20 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
 # Binaries for programs and plugins
 *.exe
 *.exe~
 *.dll
 *.so
 *.dylib
-
 # Test binary, built with `go test -c`
 *.test
-
+.idea/*
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Go workspace file
+go.work

--- a/client/client.go
+++ b/client/client.go
@@ -1,27 +1,26 @@
 package client
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 )
 
+// todo unMarshal the responses into objects.
+// todo only forward body elements required along, not all of request.
+
 type Client struct {
-	Api_key string
-	Api_url string
-	Timeout int    //todo set default, better datatype.
-	Version int    //todo set default, better datatype.
-	Session string //todo find why this is passed.
+	Api_key      string
+	Api_url      string
+	Redirect_url string
 }
 
-func New(api_key string, api_url string, timeout int, version int, session string) Client {
-	c := Client{api_key, api_url, timeout, version, session}
+func New(api_key string, api_url string, redirect_url string) Client {
+	c := Client{api_key, api_url, redirect_url}
 	return c
-}
-
-func (c Client) PrintConfig() {
-	fmt.Println(c.Api_url)
 }
 
 func (c Client) defaultHeaders() http.Header {
@@ -36,9 +35,51 @@ func (c Client) userAgent() string {
 	return "Authsignal Python v1" // todo make module version dynamic
 }
 
+func (c Client) PrintConfig() {
+	fmt.Println(c.Api_url)
+}
+
 func (c Client) GetUser(user_id string) string {
+	return c.makeRequest("GET", c.Api_url+"/v1/users/"+user_id, nil)
+}
+
+func (c Client) TrackAction(request TrackRequest) string {
+	url := c.Api_url + "/v1/users/" + request.UserId + "/actions/" + request.Action
+
+	body, _ := json.Marshal(request)
+
+	return c.makeRequest("POST", url, bytes.NewBuffer(body))
+}
+
+func (c Client) GetAction(request GetActionRequest) string {
+	url := c.Api_url + "/v1/users/" + request.UserId + "/actions/" + request.Action + "/" + request.IdempotencyKey
+
+	return c.makeRequest("GET", url, nil)
+}
+
+func (c Client) EnrollVerifiedAuthenticator(request EnrollVerifiedAuthenticatorRequest) string {
+	url := c.Api_url + "/v1/users/" + request.UserId + "authenticators"
+
+	body, _ := json.Marshal(request)
+
+	return c.makeRequest("POST", url, bytes.NewBuffer(body))
+}
+
+func (c Client) LoginWithEmail(request LoginWithEmailRequest) string {
+	url := c.Api_url + "/v1/users/email/" + request.Email + "/challenge"
+
+	body, _ := json.Marshal(request)
+
+	return c.makeRequest("POST", url, bytes.NewBuffer(body))
+}
+
+func (c Client) ValidateChallenge(request ValidateChallengeRequest) string {
+	return "NOT YET IMPLEMENTED"
+}
+
+func (c Client) makeRequest(method string, url string, body io.Reader) string {
 	client := http.Client{}
-	req, err := http.NewRequest("GET", c.Api_url+"/v1/users/"+user_id, nil)
+	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -57,11 +98,11 @@ func (c Client) GetUser(user_id string) string {
 		}
 	}(resp.Body)
 
-	body, err := io.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	sb := string(body)
+	sb := string(responseBody)
 	return sb
 }

--- a/client/client.go
+++ b/client/client.go
@@ -9,9 +9,17 @@ import (
 	"time"
 )
 
-// todo do you want the Errors remapped to a Authsignal one or is the strategy to leave dependencies escalating their own errors.
-// todo only forward body elements required along, not all requests.
-// todo Context for HTTP requests to put the Timeout + other config in.
+/*
+This is the AuthSignal Go Lang SDK.
+The module wraps the AuthSignal APIs with a Go Lang implementation allowing easier integration.
+
+Notable decisions:
+- We have a 10-second timeout set, as response speed is controlled by Authsignal.
+- We do not remap errors from any libraries are dependent on, changing such libraries should be considered
+  a breaking change as users for the SDK are bound to the libraries versions.
+  This was made because we do not have many libraries, and they are core golang libraries.
+*/
+// Todo it could be better to use Context for HTTP requests to put the Timeout + other config in.
 // Todo deal with HTTP status code.
 
 const RequestTimeout = 10 * time.Second

--- a/client/client.go
+++ b/client/client.go
@@ -11,6 +11,8 @@ import (
 
 // todo do you want the Errors remapped to a Authsignal one or is the strategy to leave dependencies escalating their own errors.
 // todo only forward body elements required along, not all requests.
+// todo Context for HTTP requests to put the Timeout + other config in.
+// Todo deal with HTTP status code.
 
 const RequestTimeout = 10 * time.Second
 
@@ -141,8 +143,6 @@ func (c Client) makeRequest(method, path string, body io.Reader) ([]byte, error)
 
 	req.Header = c.defaultHeaders()
 	req.SetBasicAuth(c.apiKey, "")
-	// todo Context for HTTP requests to put the Timeout + other config in.
-	// Todo deal with HTTP status code.
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/client/client.go
+++ b/client/client.go
@@ -19,9 +19,8 @@ Notable decisions:
   a breaking change as users for the SDK are bound to the libraries versions.
   This was made because we do not have many libraries, and they are core golang libraries.
 */
-// Todo it could be better to use Context for HTTP requests to put the Timeout + other config in.
-// Todo deal with HTTP status code.
 
+// RequestTimeout Todo improvement: timout could be done in context.
 const RequestTimeout = 10 * time.Second
 
 type Client struct {
@@ -115,7 +114,7 @@ func (c Client) LoginWithEmail(request LoginWithEmailRequest) (LoginWithEmailRes
 		return LoginWithEmailResponse{}, err
 	}
 
-	response, err2 := c.post(fmt.Sprintf("/email/%s/challenge", request.Email), bytes.NewBuffer(body))
+	response, err2 := c.post(fmt.Sprintf("email/%s/challenge", request.Email), bytes.NewBuffer(body))
 	if err2 != nil {
 		return LoginWithEmailResponse{}, err2
 	}
@@ -162,6 +161,10 @@ func (c Client) makeRequest(method, path string, body io.Reader) ([]byte, error)
 			return //todo handle error or pass up.
 		}
 	}()
+
+	if resp.StatusCode > 299 {
+		return nil, fmt.Errorf("bad request to %s, http status code of %d, status was: %s", req.URL, resp.StatusCode, resp.Status)
+	}
 
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -143,10 +143,6 @@ func (c Client) ValidateChallenge(request ValidateChallengeRequest) (ValidateCha
 		return ValidateChallengeResponse{}, err
 	}
 
-	for key, val := range claims1 {
-		fmt.Printf("Key: %v, value: %v\n", key, val)
-	}
-
 	if userId != claims1["UserId"].(string) {
 		return ValidateChallengeResponse{}, errors.New("invalid user")
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,20 @@
+package client
+
+import "fmt"
+
+type Client struct {
+	Api_key string
+	Api_url string
+	Timeout int    //todo set default, better datatype.
+	Version int    //todo set default, better datatype.
+	Session string //todo find why this is passed.
+}
+
+func New(api_key string, api_url string, timeout int, version int, session string) Client {
+	c := Client{api_key, api_url, timeout, version, session}
+	return c
+}
+
+func (c Client) PrintConfig() {
+	fmt.Println(c.Api_url)
+}

--- a/client/client.go
+++ b/client/client.go
@@ -10,16 +10,18 @@ import (
 )
 
 // todo unMarshal the responses into objects.
-// todo only forward body elements required along, not all of request.
+// todo only forward body elements required along, not all requests.
+
+const TIMEOUT = 5
 
 type Client struct {
-	Api_key      string
-	Api_url      string
-	Redirect_url string
+	apiKey      string
+	apiUrl      string
+	redirectUrl string
 }
 
-func New(api_key string, api_url string, redirect_url string) Client {
-	c := Client{api_key, api_url, redirect_url}
+func New(apiKey string, apiUrl string, redirectUrl string) Client {
+	c := Client{apiKey, apiUrl, redirectUrl}
 	return c
 }
 
@@ -36,29 +38,38 @@ func (c Client) userAgent() string {
 }
 
 func (c Client) PrintConfig() {
-	fmt.Println(c.Api_url)
+	fmt.Println(c.apiUrl)
 }
 
-func (c Client) GetUser(user_id string) string {
-	return c.makeRequest("GET", c.Api_url+"/v1/users/"+user_id, nil)
+func (c Client) GetUser(userId string) string {
+	return c.makeRequest("GET", c.apiUrl+"/v1/users/"+userId, nil)
 }
 
-func (c Client) TrackAction(request TrackRequest) string {
-	url := c.Api_url + "/v1/users/" + request.UserId + "/actions/" + request.Action
+func (c Client) TrackAction(request TrackRequest) TrackResponse {
+	url := c.apiUrl + "/v1/users/" + request.UserId + "/actions/" + request.Action
 
 	body, _ := json.Marshal(request)
 
-	return c.makeRequest("POST", url, bytes.NewBuffer(body))
+	response := c.makeRequest("POST", url, bytes.NewBuffer(body))
+
+	var data TrackResponse
+	err := json.Unmarshal([]byte(response), &data)
+	if err != nil {
+		log.Fatalln(err)
+		return TrackResponse{}
+	}
+
+	return data
 }
 
 func (c Client) GetAction(request GetActionRequest) string {
-	url := c.Api_url + "/v1/users/" + request.UserId + "/actions/" + request.Action + "/" + request.IdempotencyKey
+	url := c.apiUrl + "/v1/users/" + request.UserId + "/actions/" + request.Action + "/" + request.IdempotencyKey
 
 	return c.makeRequest("GET", url, nil)
 }
 
 func (c Client) EnrollVerifiedAuthenticator(request EnrollVerifiedAuthenticatorRequest) string {
-	url := c.Api_url + "/v1/users/" + request.UserId + "authenticators"
+	url := c.apiUrl + "/v1/users/" + request.UserId + "authenticators"
 
 	body, _ := json.Marshal(request)
 
@@ -66,7 +77,7 @@ func (c Client) EnrollVerifiedAuthenticator(request EnrollVerifiedAuthenticatorR
 }
 
 func (c Client) LoginWithEmail(request LoginWithEmailRequest) string {
-	url := c.Api_url + "/v1/users/email/" + request.Email + "/challenge"
+	url := c.apiUrl + "/v1/users/email/" + request.Email + "/challenge"
 
 	body, _ := json.Marshal(request)
 
@@ -79,13 +90,13 @@ func (c Client) ValidateChallenge(request ValidateChallengeRequest) string {
 
 func (c Client) makeRequest(method string, url string, body io.Reader) string {
 	client := http.Client{}
+	client.Timeout = TIMEOUT
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		log.Fatalln(err)
 	}
-
 	req.Header = c.defaultHeaders()
-	req.SetBasicAuth(c.Api_key, "")
+	req.SetBasicAuth(c.apiKey, "")
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -103,6 +114,7 @@ func (c Client) makeRequest(method string, url string, body io.Reader) string {
 		log.Fatalln(err)
 	}
 
+	// todo return byte[] or unpack into a response object generically.
 	sb := string(responseBody)
 	return sb
 }

--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,11 @@
 package client
 
-import "fmt"
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
 
 type Client struct {
 	Api_key string
@@ -17,4 +22,46 @@ func New(api_key string, api_url string, timeout int, version int, session strin
 
 func (c Client) PrintConfig() {
 	fmt.Println(c.Api_url)
+}
+
+func (c Client) defaultHeaders() http.Header {
+	return http.Header{
+		"Accept":       {"*/*"},
+		"Content-Type": {"application/json"},
+		"User-Agent":   {c.userAgent()},
+	}
+}
+
+func (c Client) userAgent() string {
+	return "Authsignal Python v1" // todo make module version dynamic
+}
+
+func (c Client) GetUser(user_id string) string {
+	client := http.Client{}
+	req, err := http.NewRequest("GET", c.Api_url+"/v1/users/"+user_id, nil)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	req.Header = c.defaultHeaders()
+	req.SetBasicAuth(c.Api_key, "")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			log.Fatalln(err)
+		}
+	}(resp.Body)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	sb := string(body)
+	return sb
 }

--- a/client/types.go
+++ b/client/types.go
@@ -1,0 +1,129 @@
+package client
+
+type AuthsignalConstructor struct {
+	Secret      string
+	ApiBaseUrl  string
+	RedirectUrl string
+}
+
+type UserRequest struct {
+	UserId string
+}
+
+type UserResponse struct {
+	IsEnrolled bool
+}
+
+type TrackRequest struct {
+	UserId             string
+	Action             string
+	Email              string
+	IdempotencyKey     string
+	RedirectUrl        string
+	IpAddress          string
+	UserAgent          string
+	DeviceId           string
+	RedirectToSettings bool
+}
+
+type TrackResponse struct {
+	State          UserActionState
+	IdempotencyKey string
+	RuleIds        []string
+	Url            string
+	IsEnrolled     bool
+	ChallengeUrl   string
+}
+
+type GetActionRequest struct {
+	UserId         string
+	Action         string
+	IdempotencyKey string
+}
+
+type GetActionResponse struct {
+	State UserActionState
+}
+
+type EnrollVerifiedAuthenticatorRequest struct {
+	UserId      string `json:"userId"`
+	OobChannel  string `json:"oobChannel"`
+	PhoneNumber string `json:"phoneNumber"`
+	Email       string `json:"email"`
+}
+
+type EnrollVerifiedAuthenticatorResponse struct {
+	Authenticator UserAuthenticator
+	RecoveryCodes []string
+}
+
+type LoginWithEmailRequest struct {
+	Email       string
+	RedirectUrl string
+}
+
+type LoginWithEmailResponse struct {
+	Url string
+}
+
+type ValidateChallengeRequest struct {
+	UserId string
+	Token  string
+}
+
+type ValidateChallengeResponse struct {
+	Success bool
+	State   UserActionState
+}
+
+type UserActionState int
+
+const (
+	ALLOW = iota
+	BLOCK
+	CHALLENGE_REQUIRED
+	CHALLENGE_SUCCEEDED
+	CHALLENGE_FAILED
+)
+
+type UserAuthenticator struct {
+	UserId              string
+	UserAuthenticatorId string
+	AuthenticatorType   AuthenticatorType
+	CreatedAt           string
+	IsDefault           bool
+	VerifiedAt          string
+	IsActive            bool
+	OobChannel          OobChannel
+	OtpBinding          OtpBinding
+	PhoneNumber         string
+	Email               string
+}
+
+type AuthenticatorType int
+
+const (
+	OOB = iota
+	OTP
+)
+
+type OtpBinding struct {
+	Secret string
+	Uri    string
+}
+type OobChannel int
+
+const (
+	SMS = iota
+	EMAIL_MAGIC_LINK
+)
+
+type RedirectTokenPayload struct {
+	TenantId       string
+	PublishableKey string
+	UserId         string
+	Email          string
+	PhoneNumber    string
+	ActionCode     string
+	IdempotencyKey string
+}

--- a/client/types.go
+++ b/client/types.go
@@ -27,7 +27,7 @@ type TrackRequest struct {
 }
 
 type TrackResponse struct {
-	State          UserActionState
+	State          string
 	IdempotencyKey string
 	RuleIds        []string
 	Url            string
@@ -42,7 +42,7 @@ type GetActionRequest struct {
 }
 
 type GetActionResponse struct {
-	State UserActionState
+	State string
 }
 
 type EnrollVerifiedAuthenticatorRequest struct {
@@ -73,18 +73,8 @@ type ValidateChallengeRequest struct {
 
 type ValidateChallengeResponse struct {
 	Success bool
-	State   UserActionState
+	State   string
 }
-
-type UserActionState int
-
-const (
-	ALLOW = iota
-	BLOCK
-	CHALLENGE_REQUIRED
-	CHALLENGE_SUCCEEDED
-	CHALLENGE_FAILED
-)
 
 type UserAuthenticator struct {
 	UserId              string

--- a/client/types.go
+++ b/client/types.go
@@ -1,5 +1,7 @@
 package client
 
+import "github.com/golang-jwt/jwt"
+
 type AuthsignalConstructor struct {
 	Secret      string
 	ApiBaseUrl  string //TODO APIBaseURL
@@ -79,13 +81,13 @@ type ValidateChallengeResponse struct {
 type UserAuthenticator struct {
 	UserId              string
 	UserAuthenticatorId string
-	AuthenticatorType   AuthenticatorType
+	AuthenticatorType   string
 	CreatedAt           string
 	IsDefault           bool
 	VerifiedAt          string
 	IsActive            bool
-	OobChannel          OobChannel
-	OtpBinding          OtpBinding
+	OobChannel          string
+	OtpBinding          string
 	PhoneNumber         string
 	Email               string
 }
@@ -116,4 +118,5 @@ type RedirectTokenPayload struct {
 	PhoneNumber    string
 	ActionCode     string
 	IdempotencyKey string
+	jwt.StandardClaims
 }

--- a/client/types.go
+++ b/client/types.go
@@ -2,12 +2,12 @@ package client
 
 type AuthsignalConstructor struct {
 	Secret      string
-	ApiBaseUrl  string
+	ApiBaseUrl  string //TODO APIBaseURL
 	RedirectUrl string
 }
 
 type UserRequest struct {
-	UserId string
+	UserId string // todo ID
 }
 
 type UserResponse struct {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module authsignalgo
+
+go 1.19

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module authsignalgo
 
 go 1.19
+
+require github.com/golang-jwt/jwt v3.2.2+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=

--- a/main.go
+++ b/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"authsignalgo/client"
+	"fmt"
 )
 
 func main() {
 	c := client.Client{Api_url: "https://dev-signal.authsignal.com", Api_key: "mURA8eRlODYiEd+butwzGp/5GTaC3tyEoFcufvVxtd0OoJYVK9EVuA==", Version: 1, Timeout: 2, Session: ""}
 	c.PrintConfig()
+	fmt.Println(c.GetUser("1"))
 }

--- a/main.go
+++ b/main.go
@@ -6,11 +6,11 @@ import (
 )
 
 func main() {
-	c := client.Client{
-		Api_url:      "https://dev-signal.authsignal.com",
-		Api_key:      "mURA8eRlODYiEd+butwzGp/5GTaC3tyEoFcufvVxtd0OoJYVK9EVuA==",
-		Redirect_url: "",
-	}
+	c := client.New(
+		"https://dev-signal.authsignal.com",
+		"mURA8eRlODYiEd+butwzGp/5GTaC3tyEoFcufvVxtd0OoJYVK9EVuA==",
+		"")
+
 	c.PrintConfig()
 	fmt.Println(c.GetUser("1"))
 
@@ -28,7 +28,7 @@ func main() {
 	fmt.Println("Login With Email")
 	loginWithEmailRequest := client.LoginWithEmailRequest{
 		Email:       "test@email.me",
-		RedirectUrl: "http://www.authsignal.com",
+		RedirectUrl: "https://www.authsignal.com",
 	}
 	fmt.Println(c.LoginWithEmail(loginWithEmailRequest))
 

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func main() {
 	}
 	response, err := c.EnrollVerifiedAuthenticator(enrollVerifiedAuthenticatorRequest)
 	if err != nil {
-		println(err)
+		fmt.Println(err)
 	}
 	fmt.Println(response)
 

--- a/main.go
+++ b/main.go
@@ -11,7 +11,8 @@ func main() {
 		"mURA8eRlODYiEd+butwzGp/5GTaC3tyEoFcufvVxtd0OoJYVK9EVuA==",
 		"")
 
-	c.PrintConfig()
+	fmt.Println()
+	fmt.Println("Get User")
 	fmt.Println(c.GetUser("1"))
 
 	fmt.Println()
@@ -22,7 +23,11 @@ func main() {
 		PhoneNumber: "024525252",
 		Email:       "test@email.me",
 	}
-	fmt.Println(c.EnrollVerifiedAuthenticator(enrollVerifiedAuthenticatorRequest))
+	response, err := c.EnrollVerifiedAuthenticator(enrollVerifiedAuthenticatorRequest)
+	if err != nil {
+		println(err)
+	}
+	fmt.Println(response)
 
 	fmt.Println()
 	fmt.Println("Login With Email")

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func main() {
 	fmt.Println("Enroll Verified Authenticator")
 	enrollVerifiedAuthenticatorRequest := client.EnrollVerifiedAuthenticatorRequest{
 		UserId:      "1",
-		OobChannel:  "blah",
+		OobChannel:  "EMAIL_MAGIC_LINK",
 		PhoneNumber: "024525252",
 		Email:       "test@email.me",
 	}

--- a/main.go
+++ b/main.go
@@ -6,7 +6,46 @@ import (
 )
 
 func main() {
-	c := client.Client{Api_url: "https://dev-signal.authsignal.com", Api_key: "mURA8eRlODYiEd+butwzGp/5GTaC3tyEoFcufvVxtd0OoJYVK9EVuA==", Version: 1, Timeout: 2, Session: ""}
+	c := client.Client{
+		Api_url:      "https://dev-signal.authsignal.com",
+		Api_key:      "mURA8eRlODYiEd+butwzGp/5GTaC3tyEoFcufvVxtd0OoJYVK9EVuA==",
+		Redirect_url: "",
+	}
 	c.PrintConfig()
 	fmt.Println(c.GetUser("1"))
+
+	fmt.Println()
+	fmt.Println("Enroll Verified Authenticator")
+	enrollVerifiedAuthenticatorRequest := client.EnrollVerifiedAuthenticatorRequest{
+		UserId:      "1",
+		OobChannel:  "blah",
+		PhoneNumber: "024525252",
+		Email:       "test@email.me",
+	}
+	fmt.Println(c.EnrollVerifiedAuthenticator(enrollVerifiedAuthenticatorRequest))
+
+	fmt.Println()
+	fmt.Println("Login With Email")
+	loginWithEmailRequest := client.LoginWithEmailRequest{
+		Email:       "test@email.me",
+		RedirectUrl: "http://www.authsignal.com",
+	}
+	fmt.Println(c.LoginWithEmail(loginWithEmailRequest))
+
+	fmt.Println()
+	fmt.Println("Tracking Request")
+	trackRequest := client.TrackRequest{
+		UserId: "1",
+		Action: "ABC",
+	}
+	fmt.Println(c.TrackAction(trackRequest))
+
+	fmt.Println()
+	fmt.Println("Get Action Request")
+	getActionRequest := client.GetActionRequest{
+		UserId:         "1",
+		Action:         "ABC",
+		IdempotencyKey: "ACBD12312",
+	}
+	fmt.Println(c.GetAction(getActionRequest))
 }

--- a/main.go
+++ b/main.go
@@ -23,11 +23,7 @@ func main() {
 		PhoneNumber: "024525252",
 		Email:       "test@email.me",
 	}
-	response, err := c.EnrollVerifiedAuthenticator(enrollVerifiedAuthenticatorRequest)
-	if err != nil {
-		fmt.Println(err)
-	}
-	fmt.Println(response)
+	fmt.Println(c.EnrollVerifiedAuthenticator(enrollVerifiedAuthenticatorRequest))
 
 	fmt.Println()
 	fmt.Println("Login With Email")

--- a/main.go
+++ b/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"authsignalgo/client"
+)
+
+func main() {
+	c := client.Client{Api_url: "https://dev-signal.authsignal.com", Api_key: "mURA8eRlODYiEd+butwzGp/5GTaC3tyEoFcufvVxtd0OoJYVK9EVuA==", Version: 1, Timeout: 2, Session: ""}
+	c.PrintConfig()
+}


### PR DESCRIPTION
Implementation of AuthSignals API in GoLang.

Covering:

- GetUser
- TrackAction
- GetAction
- EnrollVerifiedAuthenticator
- LoginWithEmail
- ValidateChallenge

This was built with parity with the NodeJS application the following Commit:
https://github.com/authsignal/authsignal-node/tree/31660b43f1f36ea37a63b7169c04849ce08b0dfc

Future Improvements

- Allowing Enums in response objects, but GoLang doesn't appear to have good support for this so they are strings. I've left the Enum data types in Types.js so that this can be easily implemented by someone in the future.