### PR TITLE
Add VeriffSessionId to ValidateChallengeResponse

### DIFF
--- a/client/types.go
+++ b/client/types.go
@@ -256,6 +256,7 @@ type ValidateChallengeResponse struct {
 	Action             string `json:"action,omitempty"`
 	IdempotencyKey     string `json:"idempotencyKey,omitempty"`
 	VerificationMethod string `json:"verificationMethod,omitempty"`
+	VeriffSessionId    string `json:"veriffSessionId,omitempty"`
 }
 
 type ChallengeRequest struct {


### PR DESCRIPTION
## Summary

- Adds `VeriffSessionId` to `ValidateChallengeResponse`.
- Version will be bumped via a new git tag after merge (current latest is `v2.0.1`, this would be `v2.1.0`).