### PR TITLE
Support log event webhook batches

### DIFF
--- a/client/error.go
+++ b/client/error.go
@@ -31,3 +31,15 @@ func NewInvalidSignatureError(message string) *InvalidSignatureError {
 func (e *InvalidSignatureError) Error() string {
 	return e.Message
 }
+
+type InvalidPayloadError struct {
+	Message string
+}
+
+func NewInvalidPayloadError(message string) *InvalidPayloadError {
+	return &InvalidPayloadError{Message: message}
+}
+
+func (e *InvalidPayloadError) Error() string {
+	return e.Message
+}

--- a/client/types.go
+++ b/client/types.go
@@ -360,3 +360,17 @@ type WebhookEvent struct {
 	TenantId string                 `json:"tenantId"`
 	Data     map[string]interface{} `json:"data"`
 }
+
+type WebhookLogEvent struct {
+	Version  int                    `json:"version"`
+	Type     string                 `json:"type"`
+	Id       string                 `json:"id"`
+	Source   string                 `json:"source"`
+	Time     string                 `json:"time"`
+	TenantId string                 `json:"tenantId"`
+	Record   map[string]interface{} `json:"record"`
+}
+
+type WebhookEventBatch struct {
+	Records []WebhookLogEvent `json:"records"`
+}

--- a/client/webhook.go
+++ b/client/webhook.go
@@ -23,15 +23,65 @@ func NewWebhook(apiSecretKey string) *Webhook {
 }
 
 func (w *Webhook) ConstructEvent(payload string, signature string, tolerance int) (*WebhookEvent, error) {
+	if err := w.verifySignature(payload, signature, tolerance); err != nil {
+		return nil, err
+	}
+
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(payload), &envelope); err != nil || envelope == nil {
+		return nil, NewInvalidPayloadError("Payload format is invalid.")
+	}
+	if _, isBatch := envelope["records"]; isBatch {
+		return nil, NewInvalidPayloadError("Payload is a batch of log events. Use ConstructLogEventBatch instead.")
+	}
+
+	var event WebhookEvent
+	if err := json.Unmarshal([]byte(payload), &event); err != nil {
+		return nil, NewInvalidPayloadError("Payload format is invalid.")
+	}
+	if err := validateWebhookEvent(&event); err != nil {
+		return nil, err
+	}
+
+	return &event, nil
+}
+
+func (w *Webhook) ConstructEventWithDefaultTolerance(payload string, signature string) (*WebhookEvent, error) {
+	return w.ConstructEvent(payload, signature, DefaultTolerance)
+}
+
+func (w *Webhook) ConstructLogEventBatch(payload string, signature string, tolerance int) (*WebhookEventBatch, error) {
+	if err := w.verifySignature(payload, signature, tolerance); err != nil {
+		return nil, err
+	}
+
+	var batch WebhookEventBatch
+	if err := json.Unmarshal([]byte(payload), &batch); err != nil || batch.Records == nil {
+		return nil, NewInvalidPayloadError("Payload format is invalid. Expected a 'records' array.")
+	}
+	for i := range batch.Records {
+		if err := validateWebhookLogEvent(&batch.Records[i]); err != nil {
+			return nil, err
+		}
+	}
+
+	return &batch, nil
+}
+
+func (w *Webhook) ConstructLogEventBatchWithDefaultTolerance(payload string, signature string) (*WebhookEventBatch, error) {
+	return w.ConstructLogEventBatch(payload, signature, DefaultTolerance)
+}
+
+func (w *Webhook) verifySignature(payload string, signature string, tolerance int) error {
 	parsedSignature, err := w.parseSignature(signature)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	secondsSinceEpoch := time.Now().Unix()
 
 	if tolerance > 0 && parsedSignature.Timestamp < secondsSinceEpoch-int64(tolerance*60) {
-		return nil, NewInvalidSignatureError("Timestamp is outside the tolerance zone.")
+		return NewInvalidSignatureError("Timestamp is outside the tolerance zone.")
 	}
 
 	hmacContent := strconv.FormatInt(parsedSignature.Timestamp, 10) + "." + payload
@@ -47,19 +97,68 @@ func (w *Webhook) ConstructEvent(payload string, signature string, tolerance int
 	}
 
 	if !match {
-		return nil, NewInvalidSignatureError("Signature mismatch.")
+		return NewInvalidSignatureError("Signature mismatch.")
 	}
 
-	var event WebhookEvent
-	if err := json.Unmarshal([]byte(payload), &event); err != nil {
-		return nil, err
-	}
-
-	return &event, nil
+	return nil
 }
 
-func (w *Webhook) ConstructEventWithDefaultTolerance(payload string, signature string) (*WebhookEvent, error) {
-	return w.ConstructEvent(payload, signature, DefaultTolerance)
+func validateWebhookEvent(event *WebhookEvent) error {
+	if err := validateWebhookEnvelope(
+		event.Version,
+		event.Type,
+		event.Id,
+		event.Source,
+		event.Time,
+		event.TenantId,
+	); err != nil {
+		return err
+	}
+	if event.Data == nil {
+		return NewInvalidPayloadError("Payload is missing required field 'data'.")
+	}
+	return nil
+}
+
+func validateWebhookLogEvent(event *WebhookLogEvent) error {
+	if err := validateWebhookEnvelope(
+		event.Version,
+		event.Type,
+		event.Id,
+		event.Source,
+		event.Time,
+		event.TenantId,
+	); err != nil {
+		return err
+	}
+	if event.Record == nil {
+		return NewInvalidPayloadError("Payload is missing required field 'record'.")
+	}
+	return nil
+}
+
+func validateWebhookEnvelope(version int, eventType string, id string, source string, eventTime string, tenantId string) error {
+	if version <= 0 {
+		return NewInvalidPayloadError("Payload is missing required field 'version'.")
+	}
+
+	requiredFields := []struct {
+		name  string
+		value string
+	}{
+		{name: "type", value: eventType},
+		{name: "id", value: id},
+		{name: "source", value: source},
+		{name: "time", value: eventTime},
+		{name: "tenantId", value: tenantId},
+	}
+	for _, field := range requiredFields {
+		if strings.TrimSpace(field.value) == "" {
+			return NewInvalidPayloadError("Payload is missing required field '" + field.name + "'.")
+		}
+	}
+
+	return nil
 }
 
 type signatureHeaderData struct {

--- a/client/webhook_test.go
+++ b/client/webhook_test.go
@@ -155,6 +155,79 @@ func TestValidSignatureWhenTwoApiKeysActive(t *testing.T) {
 	}
 }
 
+func TestEventWithCustomVariables(t *testing.T) {
+	webhook := getTestWebhook()
+	payload := `{"version":1,"id":"bc1598bc-e5d6-4c69-9afb-1a6fe3469d6e","source":"https://authsignal.com","time":"2025-02-20T01:51:56.070Z","tenantId":"7752d28e-e627-4b1b-bb81-b45d68d617bc","type":"sms.created","data":{"actionCode":"smsVerify","customVariables":{"action_journeyType":"ForgotChangePassword","retryCount":2,"isRecovery":true,"channels":["sms","email"]}}}`
+	timestamp := time.Now().Unix()
+
+	event, err := webhook.ConstructEvent(payload, generateTestSignature(payload, timestamp, testSecretKey), DefaultTolerance)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	customVariables, ok := event.Data["customVariables"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected customVariables to be an object, got %T", event.Data["customVariables"])
+	}
+
+	if customVariables["action_journeyType"] != "ForgotChangePassword" {
+		t.Errorf("Expected journey type to be preserved, got %v", customVariables["action_journeyType"])
+	}
+	if customVariables["retryCount"] != float64(2) {
+		t.Errorf("Expected numeric value to be preserved, got %v", customVariables["retryCount"])
+	}
+	if customVariables["isRecovery"] != true {
+		t.Errorf("Expected boolean value to be preserved, got %v", customVariables["isRecovery"])
+	}
+	channels, ok := customVariables["channels"].([]interface{})
+	if !ok || len(channels) != 2 || channels[0] != "sms" || channels[1] != "email" {
+		t.Errorf("Expected array value to be preserved, got %v", customVariables["channels"])
+	}
+}
+
+func TestLogEventBatch(t *testing.T) {
+	webhook := getTestWebhook()
+	payload := `{"records":[{"version":1,"id":"bc1598bc-e5d6-4c69-9afb-1a6fe3469d6e","source":"https://authsignal.com","time":"2025-02-20T01:51:56.070Z","tenantId":"7752d28e-e627-4b1b-bb81-b45d68d617bc","type":"action.log_created","record":{"userId":"b9f74d36-fcfc-4efc-87f1-3664ab5a7fb0","customVariables":{"journeyType":"accountRecovery"}}}]}`
+	timestamp := time.Now().Unix()
+
+	batch, err := webhook.ConstructLogEventBatchWithDefaultTolerance(
+		payload,
+		generateTestSignature(payload, timestamp, testSecretKey),
+	)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if len(batch.Records) != 1 {
+		t.Fatalf("Expected one record, got %d", len(batch.Records))
+	}
+	customVariables, ok := batch.Records[0].Record["customVariables"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected customVariables to be an object, got %T", batch.Records[0].Record["customVariables"])
+	}
+	if customVariables["journeyType"] != "accountRecovery" {
+		t.Errorf("Expected journey type to be preserved, got %v", customVariables["journeyType"])
+	}
+}
+
+func TestLogEventBatchPassedToConstructEvent(t *testing.T) {
+	webhook := getTestWebhook()
+	payload := `{"records":[]}`
+	timestamp := time.Now().Unix()
+
+	_, err := webhook.ConstructEvent(
+		payload,
+		generateTestSignature(payload, timestamp, testSecretKey),
+		DefaultTolerance,
+	)
+	if err == nil {
+		t.Fatal("Expected an error to be returned")
+	}
+	if err.Error() != "Payload is a batch of log events. Use ConstructLogEventBatch instead." {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
 func TestValidSignatureWithOldKeyFirst(t *testing.T) {
 	webhook := getTestWebhook()
 
@@ -312,9 +385,9 @@ func TestInvalidJSON(t *testing.T) {
 		return
 	}
 
-	_, ok := err.(*InvalidSignatureError)
-	if ok {
-		t.Error("Expected JSON error, not InvalidSignatureError")
+	_, ok := err.(*InvalidPayloadError)
+	if !ok {
+		t.Errorf("Expected InvalidPayloadError, got %T", err)
 	}
 }
 


### PR DESCRIPTION
### Breaking Changes

None.

### New Features

- Add support for constructing and validating batched log webhook events.
- Add payload validation with clear errors for malformed events.
- Add regression coverage for structured `customVariables` values.

### Bug Fixes

- Prevent log event batches from being parsed as single webhook events.

### Checklist

- [ ] Version bumped — handled when publishing the GitHub release
- [ ] Documentation updated — N/A
